### PR TITLE
Add chart preview page with download buttons for train/test data and forecast PNG

### DIFF
--- a/web_app/app.py
+++ b/web_app/app.py
@@ -3,12 +3,14 @@ from flask import Flask, render_template
 from routes.predict import predict_bp
 from routes.upload_model import upload_bp
 from routes.preprocess import preprocess_bp
+from routes.visualize import visualize_bp
 from utils.model_utils import get_available_models, get_history_stats
 
 app = Flask(__name__)
 app.register_blueprint(predict_bp)
 app.register_blueprint(upload_bp)
 app.register_blueprint(preprocess_bp)
+app.register_blueprint(visualize_bp)
 
 
 @app.route('/')

--- a/web_app/routes/predict.py
+++ b/web_app/routes/predict.py
@@ -8,6 +8,7 @@ import joblib
 from tensorflow.keras.models import load_model
 
 from utils.preprocessing import preprocess_dataframe
+from utils.chart_utils import plot_forecast
 
 predict_bp = Blueprint("predict_bp", __name__)
 
@@ -67,6 +68,11 @@ def predict():
     excel_path = os.path.join(DOWNLOAD_DIR, "forecast.xlsx")
     result_df.to_csv(csv_path, index=False)
     result_df.to_excel(excel_path, index=False)
+
+    # save chart image
+    chart_path = os.path.join("static", "charts", "forecast.png")
+    actual_vals = result_df.get("Actual").tolist() if "Actual" in result_df.columns else None
+    plot_forecast(dates, actual_vals, preds, save_path=chart_path)
 
     # log history
     history = []

--- a/web_app/routes/visualize.py
+++ b/web_app/routes/visualize.py
@@ -1,0 +1,37 @@
+import os
+import pandas as pd
+from flask import Blueprint, render_template, send_from_directory
+
+visualize_bp = Blueprint("visualize_bp", __name__)
+
+DOWNLOAD_DIR = "downloads"
+CHART_DIR = os.path.join("static", "charts")
+CHART_FILE = "forecast.png"
+
+
+@visualize_bp.route("/visualize")
+def visualize_page():
+    """Render forecast result page with data previews."""
+    train_path = os.path.join(DOWNLOAD_DIR, "train_processed.csv")
+    test_path = os.path.join(DOWNLOAD_DIR, "test_processed.csv")
+    train_preview, test_preview = [], []
+    if os.path.exists(train_path):
+        train_preview = pd.read_csv(train_path).head().to_dict(orient="records")
+    if os.path.exists(test_path):
+        test_preview = pd.read_csv(test_path).head().to_dict(orient="records")
+    return render_template(
+        "chart_result.html", train_preview=train_preview, test_preview=test_preview
+    )
+
+
+@visualize_bp.route("/visualize/download/<which>")
+def download_processed(which: str):
+    """Download processed train or test CSV."""
+    filename = "train_processed.csv" if which == "train" else "test_processed.csv"
+    return send_from_directory(DOWNLOAD_DIR, filename, as_attachment=True)
+
+
+@visualize_bp.route("/visualize/download/chart")
+def download_chart():
+    """Download forecast chart PNG."""
+    return send_from_directory(CHART_DIR, CHART_FILE, as_attachment=True)

--- a/web_app/templates/chart_result.html
+++ b/web_app/templates/chart_result.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forecast Result</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h1 class="mb-4">Forecast Result</h1>
+    <div class="mb-3">
+        <a href="/visualize/download/train" class="btn btn-primary btn-sm me-2">Download Train</a>
+        <a href="/visualize/download/test" class="btn btn-primary btn-sm me-2">Download Test</a>
+        <a href="/visualize/download/chart" class="btn btn-secondary btn-sm">Download Chart</a>
+    </div>
+    {% if train_preview %}
+    <h3>Train Preview</h3>
+    <div class="table-responsive mb-4">
+        <table class="table table-dark table-bordered">
+            <thead>
+            <tr>
+                {% for col in train_preview[0].keys() %}
+                <th>{{ col }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in train_preview %}
+            <tr>
+                {% for val in row.values() %}
+                <td>{{ val }}</td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    {% if test_preview %}
+    <h3>Test Preview</h3>
+    <div class="table-responsive mb-4">
+        <table class="table table-dark table-bordered">
+            <thead>
+            <tr>
+                {% for col in test_preview[0].keys() %}
+                <th>{{ col }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in test_preview %}
+            <tr>
+                {% for val in row.values() %}
+                <td>{{ val }}</td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+    <h3>Forecast Chart</h3>
+    <img src="{{ url_for('static', filename='charts/forecast.png') }}" class="img-fluid" alt="Forecast Chart">
+</div>
+</body>
+</html>

--- a/web_app/utils/chart_utils.py
+++ b/web_app/utils/chart_utils.py
@@ -1,0 +1,19 @@
+import os
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+
+def plot_forecast(dates, actual, predicted, save_path="static/charts/forecast.png"):
+    """Plot actual vs predicted values and save to PNG."""
+    os.makedirs(os.path.dirname(save_path), exist_ok=True)
+    plt.figure(figsize=(10, 4))
+    if actual is not None:
+        plt.plot(dates, actual, label="Actual")
+    plt.plot(dates, predicted, label="Predicted")
+    plt.xlabel("Date")
+    plt.ylabel("Value")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(save_path)
+    plt.close()


### PR DESCRIPTION
## Summary
- add blueprint to visualize results
- generate PNG charts server-side
- preview train and test processed data with chart image
- expose downloads for train/test CSV and forecast chart

## Testing
- `pip install -r web_app/requirements.txt`
- `python -m compileall -q web_app`


------
https://chatgpt.com/codex/tasks/task_e_684fdacf7aac832abb00e29909dd5c90