### PR TITLE
Add Upload Model feature with file validation and UI integration

### DIFF
--- a/web_app/routes/upload_model.py
+++ b/web_app/routes/upload_model.py
@@ -1,12 +1,21 @@
-from flask import Blueprint, request, jsonify
 import os
+from datetime import datetime
+from flask import Blueprint, request, jsonify, render_template
+from werkzeug.utils import secure_filename
+from utils.model_utils import get_available_models
 
 upload_bp = Blueprint("upload_bp", __name__)
 
 MODEL_DIR = "models"
 
+@upload_bp.route("/upload_model/")
+def upload_model_page():
+    """Render upload model page with list of existing models."""
+    models = get_available_models(MODEL_DIR)
+    return render_template("upload_model.html", models=models)
 
-@upload_bp.route("/upload_model", methods=["POST"])
+
+@upload_bp.route("/upload_model/submit", methods=["POST"])
 def upload_model():
     """Upload a model file to the models directory."""
     if "model_file" not in request.files:
@@ -16,10 +25,27 @@ def upload_model():
     if file.filename == "":
         return jsonify({"error": "No filename"}), 400
 
-    if not file.filename.endswith((".pkl", ".joblib", ".h5")):
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in {".pkl", ".h5"}:
         return jsonify({"error": "Unsupported model format"}), 400
 
     os.makedirs(MODEL_DIR, exist_ok=True)
-    save_path = os.path.join(MODEL_DIR, file.filename)
+
+    base_name = request.form.get("model_name") or os.path.splitext(file.filename)[0]
+    base_name = secure_filename(base_name)
+    filename = f"{base_name}{ext}"
+    save_path = os.path.join(MODEL_DIR, filename)
+    counter = 1
+    while os.path.exists(save_path):
+        filename = f"{base_name}_{counter}{ext}"
+        save_path = os.path.join(MODEL_DIR, filename)
+        counter += 1
+
     file.save(save_path)
-    return jsonify({"name": file.filename})
+
+    # append log
+    log_path = os.path.join(MODEL_DIR, "upload.log")
+    with open(log_path, "a") as f:
+        f.write(f"{datetime.utcnow().isoformat()} - {filename}\n")
+
+    return jsonify({"name": filename})

--- a/web_app/static/js/app.js
+++ b/web_app/static/js/app.js
@@ -18,7 +18,7 @@ document.getElementById('upload-form').addEventListener('submit', async function
 document.getElementById('model-upload-form').addEventListener('submit', async function(e){
     e.preventDefault();
     const formData = new FormData(this);
-    const response = await fetch('/upload_model', {method: 'POST', body: formData});
+    const response = await fetch('/upload_model/submit', {method: 'POST', body: formData});
     const data = await response.json();
     if (data.error) {
         alert(data.error);

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -14,7 +14,7 @@
         <div class="list-group list-group-flush">
             <a class="list-group-item list-group-item-action list-group-item-dark p-3" href="#forecast-section">Dự báo</a>
             <a class="list-group-item list-group-item-action list-group-item-dark p-3" href="/preprocess">Tiền xử lý</a>
-            <a class="list-group-item list-group-item-action list-group-item-dark p-3" href="#model-section">Upload Model</a>
+            <a class="list-group-item list-group-item-action list-group-item-dark p-3" href="/upload_model">Upload Model</a>
             <a class="list-group-item list-group-item-action list-group-item-dark p-3" href="#history-section">Lịch sử</a>
         </div>
     </div>
@@ -85,7 +85,7 @@
             <div id="model-section" class="card mt-5">
                 <div class="card-header">Upload Model</div>
                 <div class="card-body">
-                    <form id="model-upload-form" enctype="multipart/form-data">
+                    <form id="model-upload-form" action="/upload_model/submit" enctype="multipart/form-data">
                         <div class="row g-2 align-items-center">
                             <div class="col-md-9">
                                 <input type="file" class="form-control" name="model_file" required>

--- a/web_app/templates/upload_model.html
+++ b/web_app/templates/upload_model.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Upload Model</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h1>Upload Model</h1>
+    <form action="/upload_model/submit" method="post" enctype="multipart/form-data" class="mb-4">
+        <div class="mb-3">
+            <input type="file" class="form-control" name="model_file" accept=".pkl,.h5" required>
+        </div>
+        <div class="mb-3">
+            <input type="text" class="form-control" name="model_name" placeholder="Model name (optional)">
+        </div>
+        <button type="submit" class="btn btn-primary">Upload</button>
+    </form>
+    {% if models %}
+    <h2 class="mt-4">Existing Models</h2>
+    <ul class="list-group">
+        {% for m in models %}
+        <li class="list-group-item list-group-item-dark">{{ m }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add upload model page
- add server-side handling for upload with validation and auto rename
- link dashboard to new upload page and adjust form
- update JS to post to new route

## Testing
- `python -m py_compile web_app/routes/upload_model.py`
- `find web_app -name '*.py' -print0 | xargs -0 python -m py_compile`
- `node -e "require('fs').readFile('web_app/static/js/app.js', 'utf8', (e,d)=>{if(e)throw e;});"`

------
https://chatgpt.com/codex/tasks/task_e_684fdfd07970832ab1f5fe6f9fefa49d