### PR TITLE
Add model management: delete and metadata

### DIFF
--- a/web_app/static/js/app.js
+++ b/web_app/static/js/app.js
@@ -18,7 +18,11 @@ document.getElementById('upload-form').addEventListener('submit', async function
 document.getElementById('model-upload-form').addEventListener('submit', async function(e){
     e.preventDefault();
     const formData = new FormData(this);
-    const response = await fetch('/upload_model/submit', {method: 'POST', body: formData});
+    const response = await fetch('/upload_model/submit', {
+        method: 'POST',
+        body: formData,
+        headers: {'X-Requested-With': 'XMLHttpRequest'}
+    });
     const data = await response.json();
     if (data.error) {
         alert(data.error);

--- a/web_app/templates/upload_model.html
+++ b/web_app/templates/upload_model.html
@@ -18,12 +18,22 @@
         <button type="submit" class="btn btn-primary">Upload</button>
     </form>
     {% if models %}
-    <h2 class="mt-4">Existing Models</h2>
-    <ul class="list-group">
+    <div class="card p-3">
+      <h5 class="mb-3 text-success">📚 Danh sách Mô Hình Đã Tải Lên</h5>
+      <ul class="list-group list-group-flush">
         {% for m in models %}
-        <li class="list-group-item list-group-item-dark">{{ m }}</li>
+        <li class="list-group-item d-flex justify-content-between align-items-center bg-dark text-light">
+          <div>
+            <strong>{{ m.name }}</strong>
+            <span class="text-muted small ms-2">({{ m.size }} KB • {{ m.upload_time }} • {{ m.type }})</span>
+          </div>
+          <form action="/upload_model/delete/{{ m.name }}" method="post" onsubmit="return confirm('Xác nhận xoá mô hình {{ m.name }}?');">
+            <button class="btn btn-sm btn-danger">Xóa</button>
+          </form>
+        </li>
         {% endfor %}
-    </ul>
+      </ul>
+    </div>
     {% endif %}
 </div>
 </body>

--- a/web_app/utils/model_utils.py
+++ b/web_app/utils/model_utils.py
@@ -20,6 +20,24 @@ def get_available_models(model_dir: str = "models") -> List[str]:
     ]
 
 
+def get_model_details(model_dir: str = "models") -> List[Dict[str, object]]:
+    """Return detailed info for models in model_dir."""
+    path = Path(model_dir)
+    if not path.exists():
+        path.mkdir(parents=True, exist_ok=True)
+    models = []
+    for p in path.iterdir():
+        if p.suffix in {".pkl", ".joblib", ".h5"}:
+            stat = p.stat()
+            models.append({
+                "name": p.name,
+                "size": round(stat.st_size / 1024, 1),
+                "upload_time": datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M"),
+                "type": p.suffix.upper().strip(".")
+            })
+    return models
+
+
 def get_history_stats(history_file: str = "downloads/history.json") -> Dict[str, object]:
     """Return run count and last run timestamp from history file."""
     path = Path(history_file)


### PR DESCRIPTION
## Summary
- display model details on upload page
- allow deleting uploaded models from the UI
- auto rename duplicate uploads and redirect for normal forms
- expose helper `get_model_details`
- use AJAX header when uploading models via the dashboard

## Testing
- `python -m py_compile web_app/routes/upload_model.py web_app/utils/model_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe2b355cc832a965c6b7e978a8c40