### PR TITLE
Add unified forecast API

### DIFF
--- a/web_app/app.py
+++ b/web_app/app.py
@@ -4,6 +4,7 @@ from routes.predict import predict_bp
 from routes.upload_model import upload_bp
 from routes.preprocess import preprocess_bp
 from routes.visualize import visualize_bp
+from routes.forecast import forecast_bp
 from utils.model_utils import get_available_models, get_history_stats
 
 app = Flask(__name__)
@@ -11,6 +12,7 @@ app.register_blueprint(predict_bp)
 app.register_blueprint(upload_bp)
 app.register_blueprint(preprocess_bp)
 app.register_blueprint(visualize_bp)
+app.register_blueprint(forecast_bp)
 
 
 @app.route('/')

--- a/web_app/routes/forecast.py
+++ b/web_app/routes/forecast.py
@@ -1,0 +1,107 @@
+import os
+import json
+from datetime import datetime
+from flask import Blueprint, request, jsonify, send_from_directory, render_template
+import pandas as pd
+import joblib
+from tensorflow.keras.models import load_model
+
+from utils.preprocessing import preprocess_dataframe
+from utils.chart_utils import plot_forecast
+
+forecast_bp = Blueprint("forecast_bp", __name__)
+
+MODEL_DIR = "models"
+DOWNLOAD_DIR = "downloads"
+CHART_DIR = os.path.join("static", "charts")
+CHART_FILE = "forecast.png"
+
+
+@forecast_bp.route("/forecast", methods=["POST"])
+def run_model():
+    """Upload data, run selected model and store results."""
+    if "file" not in request.files:
+        return jsonify({"error": "No file uploaded"}), 400
+
+    file = request.files["file"]
+    model_name = request.form.get("model")
+    if not model_name:
+        return jsonify({"error": "No model selected"}), 400
+
+    if file.filename.endswith(".csv"):
+        df = pd.read_csv(file)
+    elif file.filename.endswith((".xls", ".xlsx")):
+        df = pd.read_excel(file)
+    else:
+        return jsonify({"error": "Unsupported file type"}), 400
+
+    try:
+        X, dates = preprocess_dataframe(df)
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    model_path = os.path.join(MODEL_DIR, model_name)
+    if not os.path.exists(model_path):
+        return jsonify({"error": "Model not found"}), 400
+
+    if model_path.endswith((".pkl", ".joblib")):
+        model = joblib.load(model_path)
+        preds = model.predict(X).reshape(-1).tolist()
+    elif model_path.endswith(".h5"):
+        model = load_model(model_path)
+        preds = model.predict(X).reshape(-1).tolist()
+    else:
+        return jsonify({"error": "Unsupported model format"}), 400
+
+    os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+    result_df = pd.DataFrame({"Date": dates, "Predicted": preds})
+    result = {"dates": dates, "predicted": preds}
+    if "Value" in df.columns:
+        result_df["Actual"] = df["Value"].tolist()
+        result["actual"] = df["Value"].tolist()
+
+    csv_path = os.path.join(DOWNLOAD_DIR, "forecast.csv")
+    excel_path = os.path.join(DOWNLOAD_DIR, "forecast.xlsx")
+    result_df.to_csv(csv_path, index=False)
+    result_df.to_excel(excel_path, index=False)
+
+    chart_path = os.path.join(CHART_DIR, CHART_FILE)
+    actual_vals = result_df.get("Actual").tolist() if "Actual" in result_df.columns else None
+    plot_forecast(dates, actual_vals, preds, save_path=chart_path)
+
+    history_file = os.path.join(DOWNLOAD_DIR, "history.json")
+    history = []
+    if os.path.exists(history_file):
+        with open(history_file) as f:
+            try:
+                history = json.load(f)
+            except json.JSONDecodeError:
+                history = []
+    history.append({"timestamp": datetime.utcnow().isoformat()})
+    with open(history_file, "w") as f:
+        json.dump(history, f)
+
+    return jsonify(result)
+
+
+@forecast_bp.route("/forecast/result")
+def visualize_result():
+    """Render forecast result table and chart."""
+    csv_path = os.path.join(DOWNLOAD_DIR, "forecast.csv")
+    preview = []
+    if os.path.exists(csv_path):
+        preview = pd.read_csv(csv_path).head().to_dict(orient="records")
+    return render_template("forecast_result.html", preview=preview)
+
+
+@forecast_bp.route("/forecast/download/<ftype>")
+def download_file(ftype: str):
+    """Download forecast results as csv or excel."""
+    filename = "forecast.csv" if ftype == "csv" else "forecast.xlsx"
+    return send_from_directory(DOWNLOAD_DIR, filename, as_attachment=True)
+
+
+@forecast_bp.route("/forecast/download/chart")
+def download_chart():
+    """Download forecast chart PNG."""
+    return send_from_directory(CHART_DIR, CHART_FILE, as_attachment=True)

--- a/web_app/templates/forecast_result.html
+++ b/web_app/templates/forecast_result.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Forecast Result</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/darkly/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container mt-4">
+    <h1 class="mb-4">Forecast Result</h1>
+    <div class="mb-3">
+        <a href="/forecast/download/csv" class="btn btn-primary btn-sm me-2">Download CSV</a>
+        <a href="/forecast/download/excel" class="btn btn-primary btn-sm me-2">Download Excel</a>
+        <a href="/forecast/download/chart" class="btn btn-secondary btn-sm">Download Chart</a>
+    </div>
+    {% if preview %}
+    <div class="table-responsive mb-4">
+        <table class="table table-dark table-bordered">
+            <thead>
+            <tr>
+                {% for col in preview[0].keys() %}
+                <th>{{ col }}</th>
+                {% endfor %}
+            </tr>
+            </thead>
+            <tbody>
+            {% for row in preview %}
+            <tr>
+                {% for val in row.values() %}
+                <td>{{ val }}</td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+    <h3>Forecast Chart</h3>
+    <img src="{{ url_for('static', filename='charts/forecast.png') }}" class="img-fluid" alt="Forecast Chart">
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce new blueprint `forecast_bp` with `/forecast` endpoint
- allow forecasting, result preview, and downloads
- render results with new `forecast_result.html`
- register `forecast_bp` in main Flask app

## Testing
- `python3 -m py_compile web_app/routes/forecast.py web_app/app.py`
- `python3 -m py_compile web_app/routes/*.py web_app/utils/*.py`
- `python3 -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684ff1cbeb68832aafc1cb9c1a6a0b92