### PR TITLE
Add explanation feature for preprocessing steps

### DIFF
--- a/docs/minmax.md
+++ b/docs/minmax.md
@@ -1,0 +1,20 @@
+### 🔢 MinMax Scaler
+
+**Công thức:**
+$$
+x_{scaled} = \frac{x - x_{min}}{x_{max} - x_{min}}
+$$
+
+**Ý nghĩa:**
+Đưa dữ liệu về khoảng [0, 1] để giúp mô hình học hiệu quả hơn, tránh lệch tỉ lệ giữa các đặc trưng.
+
+**Ví dụ:**
+
+Giả sử:
+- \(x = 150\)
+- \(x_{min} = 100\), \(x_{max} = 200\)
+
+Khi đó:
+$$
+x_{scaled} = \frac{150 - 100}{200 - 100} = 0.5
+$$

--- a/docs/rolling_mean.md
+++ b/docs/rolling_mean.md
@@ -1,0 +1,16 @@
+### 📈 Rolling Mean
+
+**Công thức:**
+$$
+RM_t = \frac{1}{k} \sum_{i=0}^{k-1} x_{t-i}
+$$
+trong đó \(k\) là kích thước cửa sổ.
+
+**Ý nghĩa:**
+Làm mượt chuỗi thời gian để giảm nhiễu, giúp mô hình tập trung vào xu hướng dài hạn.
+
+**Ví dụ:**
+Với k=3 và chuỗi [1,2,3,4], giá trị rolling mean tại bước 4:
+$$
+RM_4 = \frac{2+3+4}{3} = 3
+$$

--- a/docs/ssa.md
+++ b/docs/ssa.md
@@ -1,0 +1,10 @@
+### 🧮 Singular Spectrum Analysis (SSA)
+
+**Công thức:**
+SSA phân tách chuỗi thời gian \(x_t\) thành các thành phần thông qua phân rã ma trận trajectory.
+
+**Ý nghĩa:**
+Giúp khử nhiễu và trích xuất khuynh hướng, chu kỳ trong dữ liệu trước khi dự báo.
+
+**Ví dụ:**
+Một chuỗi doanh số được biểu diễn thành ma trận Hankel, sau đó lấy các thành phần chính (SVD) để tái tạo tín hiệu sạch hơn.

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -5,6 +5,7 @@ from routes.upload_model import upload_bp
 from routes.preprocess import preprocess_bp
 from routes.visualize import visualize_bp
 from routes.forecast import forecast_bp
+from routes.explain import explain_bp
 from utils.model_utils import get_available_models, get_history_stats
 
 app = Flask(__name__)
@@ -13,6 +14,7 @@ app.register_blueprint(upload_bp)
 app.register_blueprint(preprocess_bp)
 app.register_blueprint(visualize_bp)
 app.register_blueprint(forecast_bp)
+app.register_blueprint(explain_bp)
 
 
 @app.route('/')

--- a/web_app/routes/explain.py
+++ b/web_app/routes/explain.py
@@ -1,0 +1,14 @@
+from flask import Blueprint, request, jsonify
+import os
+
+explain_bp = Blueprint('explain_bp', __name__)
+
+@explain_bp.route('/explain', methods=['POST'])
+def explain():
+    topic = request.form.get('topic', 'minmax')
+    file_path = os.path.join('docs', f'{topic}.md')
+    if not os.path.exists(file_path):
+        return jsonify({'markdown': f'## Không tìm thấy giải thích cho `{topic}`'})
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    return jsonify({'markdown': content})

--- a/web_app/static/js/preprocess.js
+++ b/web_app/static/js/preprocess.js
@@ -27,3 +27,15 @@ function renderPreview(id, rows) {
     container.innerHTML = '';
     container.appendChild(table);
 }
+
+function showExplanation(topic) {
+    fetch('/explain', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({topic: topic})
+    })
+    .then(res => res.json())
+    .then(data => {
+        document.getElementById('explanation-box').innerHTML = marked.parse(data.markdown);
+    });
+}

--- a/web_app/templates/preprocess.html
+++ b/web_app/templates/preprocess.html
@@ -14,17 +14,23 @@
             <div class="col-md-4">
                 <input type="file" class="form-control" name="file" required>
             </div>
-            <div class="col-md-2">
-                <input class="form-check-input" type="checkbox" name="ssa" id="ssa">
-                <label class="form-check-label" for="ssa">SSA</label>
+            <div class="col-md-2 d-flex align-items-center">
+                <div>
+                    <input class="form-check-input" type="checkbox" name="ssa" id="ssa">
+                    <label class="form-check-label" for="ssa">SSA</label>
+                </div>
+                <button type="button" class="btn btn-outline-info btn-sm ms-2" onclick="showExplanation('ssa')">🧠 Hiểu toán học</button>
             </div>
             <div class="col-md-2">
                 <input class="form-check-input" type="checkbox" name="wavelet" id="wavelet">
                 <label class="form-check-label" for="wavelet">Wavelet</label>
             </div>
-            <div class="col-md-2">
-                <input class="form-check-input" type="checkbox" name="rolling" id="rolling">
-                <label class="form-check-label" for="rolling">Rolling Mean</label>
+            <div class="col-md-2 d-flex align-items-center">
+                <div>
+                    <input class="form-check-input" type="checkbox" name="rolling" id="rolling">
+                    <label class="form-check-label" for="rolling">Rolling Mean</label>
+                </div>
+                <button type="button" class="btn btn-outline-info btn-sm ms-2" onclick="showExplanation('rolling_mean')">🧠 Hiểu toán học</button>
             </div>
             <div class="col-md-2">
                 <input type="number" class="form-control" name="lag" value="1" min="1" placeholder="Lag">
@@ -47,7 +53,12 @@
                 <button type="submit" class="btn btn-primary w-100">Run</button>
             </div>
         </div>
+        <div class="d-flex align-items-center mt-3">
+            <label class="form-label me-3">🔃 Chuẩn hóa bằng MinMaxScaler</label>
+            <button type="button" class="btn btn-outline-info btn-sm" onclick="showExplanation('minmax')">🧠 Hiểu toán học</button>
+        </div>
     </form>
+    <div id="explanation-box" class="p-3 border rounded bg-light mb-3" style="white-space: pre-wrap;"></div>
     <div id="result" style="display:none;">
         <h4>Train Preview</h4>
         <div id="train-table" class="table-responsive"></div>
@@ -59,6 +70,7 @@
         <a href="/download_processed/test" class="btn btn-outline-light btn-sm">Download Test</a>
     </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="/static/js/preprocess.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/explain` endpoint as a blueprint
- register the new blueprint
- create markdown docs for MinMax, SSA and Rolling Mean
- add explanation buttons to `preprocess.html`
- render markdown via marked.js and new JS helper

## Testing
- `python -m py_compile web_app/app.py web_app/routes/explain.py`

------
https://chatgpt.com/codex/tasks/task_e_685010ff5e20832aa10bd53f11e6dfb3